### PR TITLE
Typo fix

### DIFF
--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -108,7 +108,7 @@ const Sidebar = () => {
         </Box>
         <Divider color="gray.800" />
         <Box height="66%" overflowY="auto" paddingY="20px">
-          <List spaceing={2}>
+          <List spacing={2}>
             {playlists.map((playlist) => (
               <ListItem paddingX="20px" key={playlist.id}>
                 <LinkBox>


### PR DESCRIPTION
Fixed the typo of `spaceing={2}` to `spacing={2}`