### PR TITLE
Update _middleware.ts to rewrite absolute URLs

### DIFF
--- a/pages/_middleware.ts
+++ b/pages/_middleware.ts
@@ -7,7 +7,7 @@ export default function middleware(req) {
     const token = req.cookies.TRAX_ACCESS_TOKEN
 
     if (!token) {
-      return NextResponse.redirect('/signin')
+      return NextResponse.rewrite(new URL('/signin', req.url))
     }
   }
 }


### PR DESCRIPTION
closes #10

As mentioned in https://nextjs.org/docs/messages/middleware-relative-urls, Middleware Relative URLs have been deprecated and removed in Next.JS.

Updated this code to use the recommended approach to rewrite to use absolute URLs.